### PR TITLE
Add transfer list

### DIFF
--- a/parm/transfer_hgefs.list
+++ b/parm/transfer_hgefs.list
@@ -1,0 +1,56 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+_COMROOT_/hgefs/_SHORTVER_/hgefs._PDY_/
++ /??/
++ /??/ensstat/
++ /??/ensstat/products/
++ /??/ensstat/products/atmos/
++ /??/ensstat/products/atmos/grib2/
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.pres.avg.f???.grib2
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.pres.avg.f???.grib2.idx
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.sfc.avg.f???.grib2
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.sfc.avg.f???.grib2.idx
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.pres.spr.f???.grib2
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.pres.spr.f???.grib2.idx
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.sfc.spr.f???.grib2
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.sfc.spr.f???.grib2.idx
+- *
+
+_COMROOT_/hgefs/_SHORTVER_/hgefs._PDYm1_/
++ /??/
++ /??/ensstat/
++ /??/ensstat/products/
++ /??/ensstat/products/atmos/
++ /??/ensstat/products/atmos/grib2/
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.pres.avg.f???.grib2
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.pres.avg.f???.grib2.idx
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.sfc.avg.f???.grib2
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.sfc.avg.f???.grib2.idx
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.pres.spr.f???.grib2
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.pres.spr.f???.grib2.idx
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.sfc.spr.f???.grib2
++ /??/ensstat/products/atmos/grib2/hgefs.t??z.sfc.spr.f???.grib2.idx
+- *


### PR DESCRIPTION
This PR adds `parm/transfer_hgefs.list` to enable transferring COM data from the primary machine to the backup machine.