### PR TITLE
Process individual lead times and apply implementation standards

### DIFF
--- a/ecf/create_links.sh
+++ b/ecf/create_links.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# =====================================================================
+# create_links.sh
+# ---------------------------------------------------------------------
+# Create soft links for jhgefs_ensstat_fHHH.ecf in 6-hour increments.
+# =====================================================================
+
+target=jhgefs_ensstat.ecf
+for i in $(seq -w 0 6 240); do
+  ln -s $target jhgefs_ensstat_f${i}.ecf
+done
+

--- a/ecf/jhgefs_ensstat.ecf
+++ b/ecf/jhgefs_ensstat.ecf
@@ -1,10 +1,10 @@
-#PBS -N hgefs_ensstat_%CYC%
+#PBS -N hgefs_ensstat_f%FHR%_%CYC%
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
-#PBS -l walltime=00:10:00
+#PBS -l walltime=00:15:00
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l select=1:ncpus=41:mpiprocs=41:mem=150GB
+#PBS -l select=1:ncpus=1:mpiprocs=1:mem=4GB
 #PBS -l debug=true
 
 model=hgefs
@@ -13,29 +13,23 @@ model=hgefs
 %include <envir-p1.h>
 
 export cyc=%CYC%
+export nfhrs=%FHR%
 
 module load intel/${intel_ver:?}
-module load craype/${craype_ver:?}
-module load cray-mpich/${cray_mpich_ver:?}
-module load cray-pals/${cray_pals_ver:?}
-module load cfp/${cfp_ver:?}
 module load wgrib2/${wgrib2_ver:?}
 module list
 
-# EXPORT list here
-
-export export OMP_NUM_THREADS=1
-export APRUN="mpiexec -np 41 --cpu-bind core cfp "         
-export IOBUF_PARAMS='*:sync,%%stdout:sync'
-
-# CALL executable job script here
 $HOMEhgefs/jobs/JHGEFS_ENSSTAT 
-
+if [[ $? -ne 0 ]]; then
+    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT"
+    ecflow_client --abort
+    exit
+fi
 
 %include <tail.h>
 %manual
 ######################################################################
-# Purpose: Calculates the mean and spread for the 00Z aigefs ensemble.
+# Purpose: Calculates the mean and spread for hgefs at one lead time.
 ######################################################################
 
 ######################################################################

--- a/jobs/JHGEFS_ENSSTAT
+++ b/jobs/JHGEFS_ENSSTAT
@@ -17,26 +17,25 @@ date
 ########################################################
 # obtain unique process id (pid) and make temp directory
 ########################################################
-export pid=$$
-export DATA=${DATA:-${DATAROOT:?}/${pid}}
+export job=${job:-$NET}
+export jobid=${jobid:-$$}
+export DATA=${DATA:-${DATAROOT:?}/${jobid}}
 
 mkdir -p $DATA
 cd $DATA
 
 export cycle=t${cyc}z
 
-##################
-# File To Log Msgs
-##################
-
-export jlogfile=${jlogfile:-${DATA}/jlogfile.${job}.${pid}}
+#########################################
+# Run setpdy and initialize PDY variables
+#########################################
+setpdy.sh
+. ./PDY
 
 #####################################
 # Determine Job Output Name on System
 #####################################
-export outid="LL$job"
-export jobid="${outid}.o${pid}"
-export pgmout="OUTPUT.${pid}"
+export pgmout="OUTPUT.${jobid}"
 export pgmerr=errfile
 
 ##############################################################
@@ -58,29 +57,20 @@ export IFHYBRID=YES
 # Specify Execution Areas
 #########################
  
-export HOMEhgefs=${HOMEhgefs:-${PACKAGEROOT}/hgefs.${hgefs_ver}}
 export EXEChgefs=${EXEChgefs:-$HOMEhgefs/exec}
-#export FIXhgefs=${FIXhgefs:-$HOMEhgefs/fix}
-#export USHhgefs=${USHhgefs:-$HOMEhgefs/ush}
-
-#########################################
-# Run setpdy and initialize PDY variables
-#########################################
-setpdy.sh
-. ./PDY
 
 ########################
 # Define COM directories
 ########################
 
-export COMIN_AIGEFS=${COMIN_AIGEFS:-$(compath.py ${envir}/com/aigefs/${aigefs_ver}/aigefs.${PDY}/${cyc})}
-export COMIN_GEFS=${COMIN_GEFS:-$(compath.py ${envir}/com/gefs/${gefs_ver}/gefs.${PDY}/${cyc}/atmos)}
-export COMOUT=${COMOUT:-$(compath.py -o $NET/${hgefs_ver}/$RUN.${PDY}/${cyc}/ensstat/products/atmos/grib2)}
+export COMINaigefs=${COMINaigefs:-$(compath.py ${envir}/aigefs/${aigefs_ver})}/aigefs.${PDY}/${cyc}
+export COMINgefs=${COMINgefs:-$(compath.py ${envir}/gefs/${gefs_ver})}/gefs.${PDY}/${cyc}/atmos
+export COMOUT=${COMOUT:-$(compath.py -o $NET/${hgefs_ver}/$RUN.${PDY})}/${cyc}/ensstat/products/atmos/grib2
 
 mkdir -m 775 -p ${COMOUT}
 
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+msg="JOB $job HAS BEGUN on `hostname`"
+postmsg "$msg"
 
 env
 
@@ -88,15 +78,18 @@ env
 # Execute the scripts
 #####################
 
-$HOMEhgefs/scripts/exhgefs_ensstat.sh                  
+$HOMEhgefs/scripts/exhgefs_ensstat.sh
+export err=$?; err_chk "$job failed while running $HOMEhgefs/scripts/exhgefs_ensstat.sh"
 
-cat $DATA/$pgmout.120_avgspr_pres
-cat $DATA/$pgmout.240_avgspr_pres
-cat $DATA/$pgmout.120_avgspr_sfc 
-cat $DATA/$pgmout.240_avgspr_sfc
+msg="JOB $job HAS COMPLETED NORMALLY"
+postmsg "$msg"
 
-msg="JOB COMPLETED NORMALLY"
-postmsg "$jlogfile" "$msg"
+if [ -e $pgmout ]; then
+  cat $pgmout
+fi
+if [ -e $errfile ]; then
+  cat $errfile
+fi
 
 ########################################
 # Remove the Temporary working directory

--- a/jobs/JHGEFS_ENSSTAT
+++ b/jobs/JHGEFS_ENSSTAT
@@ -35,8 +35,7 @@ setpdy.sh
 #####################################
 # Determine Job Output Name on System
 #####################################
-export pgmout="OUTPUT.${jobid}"
-export pgmerr=errfile
+export pgmout="OUTPUT.$$"
 
 ##############################################################
 # SENDCOM=YES--Copy output file to ${COMROOT}
@@ -87,8 +86,8 @@ postmsg "$msg"
 if [ -e $pgmout ]; then
   cat $pgmout
 fi
-if [ -e $errfile ]; then
-  cat $errfile
+if [ -e errfile ]; then
+  cat errfile
 fi
 
 ########################################

--- a/scripts/exhgefs_ensstat.sh
+++ b/scripts/exhgefs_ensstat.sh
@@ -97,7 +97,7 @@ for prod in pres sfc; do
     echo " cfopg2='${outmodel}.t${cyc}z.${prod}.spr.f${nfhrs}.grib2'," >>namin_avgspr_${prod}_${nfhrs}
     echo " /" >>namin_avgspr_${prod}_${nfhrs}
 
-    $EXEChgefs/${pgm} <namin_avgspr_${prod}_${nfhrs} > $pgmout.${nfhrs}_avgspr_${prod}
+    $EXEChgefs/${pgm} <namin_avgspr_${prod}_${nfhrs} >> ${pgmout} 2>> errfile
     export err=$?; err_chk "$job failed while running ${pgm}"
 
   ls $DATA

--- a/scripts/exhgefs_ensstat.sh
+++ b/scripts/exhgefs_ensstat.sh
@@ -6,21 +6,15 @@
 # Author: Bo Cui ---- Oct. 2025
 # History: 
 #         2025-09-20  Bo Cui - First implementation of this new script
+#         2025-10-09  Russell Manser - modify to process individual lead times
 #################################################################################
 set -x
-cd $DATA
 
 pgm=hgefs_ensstat        
 
 #####################################
 #  calculate ensemble mean and spread
 #####################################
-
-hourlist="000 006 012 018 024 030 036 042 048 054 060 066 072 \
-          078 084 090 096 102 108 114 120 126 132 138 144 150 \
-          156 162 168 174 180 186 192 198 204 210 216 222 228 \
-          234 240 246 252 258 264 270 276 282 288 294 300 306 \
-          312 318 324 330 336 342 348 354 360 366 372 378 384"
 
 memberlist_gefs="c00 p01 p02 p03 p04 p05 p06 p07 p08 p09 p10 \
                  p11 p12 p13 p14 p15 p16 p17 p18 p19 p20 \
@@ -36,10 +30,6 @@ outmodel=aigefs
 
 if [ "$IFHYBRID" = "YES" ]; then
   outmodel=hgefs  
-  hourlist="000 006 012 018 024 030 036 042 048 054 060 066 072 \
-            078 084 090 096 102 108 114 120 126 132 138 144 150 \
-            156 162 168 174 180 186 192 198 204 210 216 222 228 \
-            234 240"
 fi
 
 ######################################################
@@ -47,8 +37,6 @@ fi
 ######################################################
 
 for prod in pres sfc; do
-
-  for nfhrs in $hourlist; do
 
     if [ -s namin_avgspr_${prod}_${nfhrs} ]; then
      rm namin_avgspr_${prod}_${nfhrs}
@@ -63,7 +51,7 @@ for prod in pres sfc; do
 #######################
 
     for mem in $memberlist_aigefs; do
-      file=$COMIN_AIGEFS/mem${mem}/model/atmos/grib2/aigefs.t${cyc}z.${prod}.f${nfhrs}.grib2
+      file=$COMINaigefs/mem${mem}/model/atmos/grib2/aigefs.t${cyc}z.${prod}.f${nfhrs}.grib2
       if [ -s $file ]; then
         (( ifile = ifile + 1 ))
         iskip=0
@@ -73,9 +61,8 @@ for prod in pres sfc; do
     done
 
     if [ $ifile -le 1 ]; then
-      echo "FATAL ERROR in exhgefs_ensstat.sh!!!"
-      echo "Fewer than 1 AIGEFS File Available For Fcst hr " $nfhrs
-      export err=1; err_chk
+      msg="Fewer than 1 AIGEFS files available for fcst hr $nfhrs"
+      export err=1; err_chk "$msg"
     fi
 
 #########################################
@@ -85,9 +72,9 @@ for prod in pres sfc; do
     if [ "$IFHYBRID" = "YES" ]; then
       for mem in $memberlist_gefs; do
         if [ "${prod}" = "pres" ]; then 
-          file=$COMIN_GEFS/pgrb2p25/ge${mem}.t${cyc}z.pgrb2.0p25.f${nfhrs}            
+          file=$COMINgefs/pgrb2p25/ge${mem}.t${cyc}z.pgrb2.0p25.f${nfhrs}            
         elif [ "${prod}" = "sfc" ]; then 
-          file=$COMIN_GEFS/pgrb2sp25/ge${mem}.t${cyc}z.pgrb2s.0p25.f${nfhrs}            
+          file=$COMINgefs/pgrb2sp25/ge${mem}.t${cyc}z.pgrb2s.0p25.f${nfhrs}            
         fi
         if [ -s $file ]; then
           (( ifile = ifile + 1 ))
@@ -98,44 +85,41 @@ for prod in pres sfc; do
       done
     fi
 
+    if [ $ifile -le 1 ]; then
+      msg="Fewer than 1 GEFS/AIGEFS files available for fcst hr $nfhrs"
+      export err=1; err_chk "$msg"
+    fi
+
+    ls $DATA
+
     echo " nfiles=${ifile}," >>namin_avgspr_${prod}_${nfhrs}
     echo " cfopg1='${outmodel}.t${cyc}z.${prod}.avg.f${nfhrs}.grib2'," >>namin_avgspr_${prod}_${nfhrs}
     echo " cfopg2='${outmodel}.t${cyc}z.${prod}.spr.f${nfhrs}.grib2'," >>namin_avgspr_${prod}_${nfhrs}
     echo " /" >>namin_avgspr_${prod}_${nfhrs}
 
-  done
+    $EXEChgefs/${pgm} <namin_avgspr_${prod}_${nfhrs} > $pgmout.${nfhrs}_avgspr_${prod}
+    export err=$?; err_chk "$job failed while running ${pgm}"
 
-  if [ -s poescript_avgspr_${prod} ]; then
-    rm poescript_avgspr_${prod}
-  fi
-
-  for nfhrs in $hourlist; do
-    if [ -s namin_avgspr_${prod}_${nfhrs} ]; then
-      echo "$EXEChgefs/${pgm} <namin_avgspr_${prod}_${nfhrs} > $pgmout.${nfhrs}_avgspr_${prod}" >> poescript_avgspr_${prod}
-    fi
-  done
-
-  chmod +x poescript_avgspr_${prod}
-  $APRUN poescript_avgspr_${prod}
-  export err=$?; err_chk
+  ls $DATA
 
   if [ "$SENDCOM" = "YES" ]; then
-    for nfhrs in $hourlist; do
       for ensstat in $ensstatlist; do
         file=${outmodel}.t${cyc}z.${prod}.${ensstat}.f$nfhrs.grib2
         if [ -s $file ]; then
-          $WGRIB2 -s $file > $file.idx
           cpfs $file $COMOUT/$file
+
+          $WGRIB2 -s $file > $file.idx
+          export err=$?; err_chk "$job failed while creating $file.idx"
           cpfs $file.idx $COMOUT/$file.idx
+
           if [ "$SENDDBN" = "YES" ]; then
             $DBNROOT/bin/dbn_alert MODEL HGEFS_ENSSTAT_GB2 $job $COMOUT/$file
             $DBNROOT/bin/dbn_alert MODEL HGEFS_ENSSTAT_GB2_IDX $job $COMOUT/$file.idx
           fi
         else
-          echo "Warning $file missing"
+          export err=1; err_chk "$file missing"
         fi
       done
-    done
   fi
 
 done

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,26 +1,5 @@
 export intel_ver=19.1.3.304
 export wgrib2_ver=2.0.8
-export python_ver=3.12
-export libjpeg_turbo_ver=2.1.0
 
 export gefs_ver="v12.3"
 export aigefs_ver="v1.0"
-export hgefs_ver="v1.0"
-
-# ens mean and spread
-export craype_ver=2.7.17
-export cray_mpich_ver=8.1.19
-export cray_pals_ver=1.0.17
-
-export cfp_ver=2.0.4
-export grib_util_ver=1.2.4
-
-export gempak_ver=7.15.1
-#export iobuf_ver=2.0.10
-
-# PARA/TEST
-#export COMPATH=/lfs/h1/ops/prod/com/hgefs
-#export MAILTO="russell.manser@noaa.gov, carlos.m.diaz@noaa.gov"
-
-#export SENDDBN=NO
-export DBNLOG=YES


### PR DESCRIPTION
- [x] Closes #5 

## Overview

This PR addresses two primary items:
- Modifications for processing individual lead times
- Application of multiple [implementation standards](https://nws-hpc-standards.readthedocs.io/en/latest/)

## Key Changes
- Remove for loops over `nfhrs` in `scripts/exhgefs_ensstat.sh` and make related changes
- Improve error handling by adding `export err=$?; err_chk` and descriptive messages
- Remove modules for parallel processing, reduce requested resources, and increase walltime to 15 minutes