### PR TITLE
Update versions to latest compatible on WCOSS

### DIFF
--- a/versions/build.ver
+++ b/versions/build.ver
@@ -2,8 +2,8 @@
 
 # 
 export intel_ver=19.1.3.304
-export PrgEnv_intel_ver=8.2.0
-export craype_ver=2.7.13
+export PrgEnv_intel_ver=8.5.0
+export craype_ver=2.7.17
 
 #export cray_mpich_ver=8.1.12
 

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -7,5 +7,5 @@ export aigefs_ver="v1.0"
 # ens mean and spread
 export craype_ver=2.7.17
 export cray_mpich_ver=8.1.19
-export cray_pals_ver=1.0.17
+export cray_pals_ver=1.3.2
 export cfp_ver=2.0.4


### PR DESCRIPTION
This PR updates build and run versions to the latest compatible versions available on WCOSS2. I have rebuilt the executable and run tests to confirm that there are no changes to output files. Please find logs below on Cactus at `/lfs/h1/nco/idsb/noscrub/russell.manser/projects/hgefs/`:

- Build log: `build.2025-11-13_1749.log`
- Job output: `hgefs_ensstat_00.o79167225`
- Bitwise comparison: `diffoutputdirs.2025-11-13_2040.log`

I have placed these changes in para and the 12Z cycle has run successfully. I will perform a bitwise comparison again on Monday and comment here with the results.

Once that is complete, if possible, please include this in the v1.0.3 tag that was just released. Otherwise a v1.0.4 tag will work just as well.