### PR TITLE
Upgrade wgrib2 to v3.8.0 and add dependencies

### DIFF
--- a/ecf/jhgefs_ensstat.ecf
+++ b/ecf/jhgefs_ensstat.ecf
@@ -19,7 +19,15 @@ module load craype/${craype_ver:?}
 module load cray-mpich/${cray_mpich_ver:?}
 module load cray-pals/${cray_pals_ver:?}
 module load cfp/${cfp_ver:?}
+module load netcdf-D/${netcdf_D_ver:?}
+module load libaec/${libaec_ver:?}
+module load ip/${ip_ver:?}
+module load g2c/${g2c_ver:?}
+module load jasper/${jasper_ver:?}
+module load libpng/${libpng_ver:?}
+module load zlib/${zlib_ver:?}
 module load wgrib2/${wgrib2_ver:?}
+module load libjpeg-turbo/${libjpeg_turbo_ver:?}
 module list
 
 export OMP_NUM_THREADS=1

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,11 +1,17 @@
 export intel_ver=19.1.3.304
-export wgrib2_ver=2.0.8
-
-export gefs_ver="v12.3"
-export aigefs_ver="v1.0"
-
-# ens mean and spread
 export craype_ver=2.7.17
 export cray_mpich_ver=8.1.19
 export cray_pals_ver=1.3.2
 export cfp_ver=2.0.4
+export netcdf_D_ver=4.9.2
+export libaec_ver=1.1.3
+export ip_ver=5.2.0
+export g2c_ver=2.3.0
+export jasper_ver=2.0.25
+export libpng_ver=1.6.37
+export zlib_ver=1.2.11
+export wgrib2_ver=3.8.0
+export libjpeg_turbo_ver=2.1.0
+
+export gefs_ver="v12.3"
+export aigefs_ver="v1.0"


### PR DESCRIPTION
This PR upgrades wgrib2 to v3.8.0 for consistency with aigefs (see https://github.com/NOAA-EMC/aigefs/pull/16 and related https://github.com/NOAA-EMC/MLGlobal/pull/67).